### PR TITLE
Allow default for --output flag.

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -585,6 +585,10 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions, debugConfig *debug.D
 	if v := os.Getenv("DOCKER_DEFAULT_PLATFORM"); v != "" {
 		platformsDefault = []string{v}
 	}
+	var outputDefault []string
+	if v := os.Getenv("DOCKER_DEFAULT_OUTPUT"); v != "" {
+		outputDefault = []string{v}
+	}
 
 	flags := cmd.Flags()
 
@@ -616,7 +620,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions, debugConfig *debug.D
 
 	flags.StringArrayVar(&options.noCacheFilter, "no-cache-filter", []string{}, "Do not cache specified stages")
 
-	flags.StringArrayVarP(&options.outputs, "output", "o", []string{}, `Output destination (format: "type=local,dest=path")`)
+	flags.StringArrayVarP(&options.outputs, "output", "o", outputDefault, `Output destination (format: "type=local,dest=path")`)
 
 	flags.StringArrayVar(&options.platforms, "platform", platformsDefault, "Set target platform for build")
 


### PR DESCRIPTION
`zstd` compression is quite popular compared to the default `gzip`. But to use `zstd`, we need to pass several parameters. For example:

```bash
docker buildx build --output type=image,oci-mediatypes=true,compression=zstd,push=true,force-compression=true --provenance=false .
```

We can use Bash aliases or scripts to make this easier, but it would be simpler if `buildx` allowed setting defaults for `--output` flag.

A possible implementation has been added to this PR.